### PR TITLE
Fixed position of page control for even page counts

### DIFF
--- a/Source/FLOPageControl.swift
+++ b/Source/FLOPageControl.swift
@@ -132,7 +132,7 @@ class FLOPageControl: NSControl {
     private func frameOfIndicator(at index: UInt) -> NSRect {
         let centerDrawingAroundSpace = (self.numberOfPages % 2 == 0)
         let centeredIndex = self.numberOfPages/2
-        let centeredFrame = NSRect(x: NSMidX(self.bounds) - (centerDrawingAroundSpace ? self.indicatorSize*1.5 : self.indicatorSize/2), y: NSMidY(self.bounds) - self.indicatorSize/2, width: self.indicatorSize, height: self.indicatorSize)
+        let centeredFrame = NSRect(x: NSMidX(self.bounds) - (centerDrawingAroundSpace ? -self.indicatorSize/2 : self.indicatorSize/2), y: NSMidY(self.bounds) - self.indicatorSize/2, width: self.indicatorSize, height: self.indicatorSize)
         let distanceToCenteredIndex = CGFloat(centeredIndex)-CGFloat(index)
         
         return NSRect(x: NSMinX(centeredFrame) - distanceToCenteredIndex*self.indicatorSize*2, y: NSMidY(self.bounds) - self.indicatorSize/2, width: self.indicatorSize, height: self.indicatorSize)


### PR DESCRIPTION
I've noticed that the page control is not centered when the page controller displays an even number of pages. This fix works fine in the sample project and in my own project.